### PR TITLE
fix: add prefix to module names starting with digits

### DIFF
--- a/src/ts/util/parse-query.ts
+++ b/src/ts/util/parse-query.ts
@@ -69,9 +69,9 @@ export const getModuleName = (str: string) => {
         .join("")
         .replace(/[^\w\s]/gi, "");
 
-    //Prefixes the module with a letter if it starts with a digit
+    // Prefixes the module with a underscore if it starts with a digit
     if (/^\d/.test(result)) {
-        result = "a" + result;
+        result = "_" + result;
     }
     return result;
 }

--- a/src/ts/util/parse-query.ts
+++ b/src/ts/util/parse-query.ts
@@ -61,13 +61,19 @@ export const getModuleName = (str: string) => {
     if (/^https?\:\/\//.test(str)) {
         _str = fromBasename(str);
     } else if (name.length > 0) {
-        _str = name + (path ? fromBasename(path) : "")
+        _str = name + (path ? fromBasename(path) : "");
     }
     
-    return _str.split(/(?:-|_|\/)/g)
+    let result = _str.split(/(?:-|_|\/)/g)
         .map((x: string | any[], i: number) => i > 0 && x.length > 0 ? (x[0].toUpperCase() + x.slice(1)) : x)
         .join("")
-        .replace(/[^\w\s]/gi, "")
+        .replace(/[^\w\s]/gi, "");
+
+    //Prefixes the module with a letter if it starts with a digit
+    if (/^\d/.test(result)) {
+        result = "a" + result;
+    }
+    return result;
 }
 
 // Inspired by https://github.com/solidjs/solid-playground


### PR DESCRIPTION
This solves an issue when adding libraries such as [@75lb/deep-merge](https://www.npmjs.com/package/@75lb/deep-merge) that results in:
```js
export * from "@75lb/deep-merge@1.1.2";
export { default as 75lbDeepMergeDefault } from "@75lb/deep-merge@1.1.2";
// Error: An identifier or keyword cannot immediately follow a numeric literal.(1351)
```
  
Checking for modules starting with a digit and prefixing them with `a` should solve the issue, even if not a perfect solution.  
I have not tested the code.
