### PR TITLE
fix: data URIs

### DIFF
--- a/packages/utils/src/utils/path.ts
+++ b/packages/utils/src/utils/path.ts
@@ -8,5 +8,5 @@ export * as windows from "@std/path/windows";
  * An import counts as a bare import if it's neither a relative import of an absolute import
  */
 export const isBareImport = (importStr: string) => {
-  return /^(?!\.).*/.test(importStr) && !isAbsolute(importStr);
+  return /^(?!\.).*/.test(importStr) && !importStr.startsWith("data:") && !isAbsolute(importStr);
 };


### PR DESCRIPTION
**Input**
`export { default as one } from "data:text/javascript;base64,ZXhwb3J0IGRlZmF1bHQgMQ=="`

splitting is turned off

**Old output**
✘ [ERROR] Invalid URL: './' with base 'data:text@latest/javascript;base64,ZXhwb3J0IGRlZmF1bHQgMQ==' [plugin http-url]

**New output**
`var e=1;export{e as one};\n`

Seems it just works after this one change in this new codebase.